### PR TITLE
Add The MCP Company as ALIGNED builder

### DIFF
--- a/builders.mdx
+++ b/builders.mdx
@@ -555,6 +555,61 @@ description: Companies building AARM-conformant systems and those aligned with t
     </div>
   </Card>
 
+  <Card href="https://themcp.company">
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "flex-start",
+        gap: "10px",
+        height: "100%",
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", gap: "12px" }}>
+        <div
+          style={{
+            height: "32px",
+            width: "160px",
+            display: "flex",
+            alignItems: "center",
+          }}
+        >
+          <img
+            src="/images/the-mcp-company.svg"
+            alt=""
+            style={{
+              height: "32px",
+              width: "100%",
+              objectFit: "contain",
+              objectPosition: "left center",
+            }}
+          />
+        </div>
+        <span style={{ fontWeight: 700, fontSize: "15px" }}>The MCP Company</span>
+      </div>
+
+      <p style={{ margin: 0, color: "#64748b", fontSize: "13px", lineHeight: 1.5 }}>
+        Dev tool giving control and visibility over their agents and their MCP actions.
+      </p>
+
+      <div style={{ marginTop: "auto" }}>
+        <span
+          style={{
+            background: "#3b82f6",
+            color: "#fff",
+            padding: "2px 8px",
+            borderRadius: "6px",
+            fontSize: "10px",
+            fontWeight: 700,
+            letterSpacing: "0.02em",
+          }}
+        >
+          ALIGNED
+        </span>
+      </div>
+    </div>
+  </Card>
+
 </CardGroup>
 
 

--- a/images/the-mcp-company.svg
+++ b/images/the-mcp-company.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64">
+  <rect x="6" y="18" width="34" height="34" fill="none" stroke="#ffffff" stroke-width="2.5"/>
+  <rect x="20" y="8" width="34" height="34" fill="#ffffff"/>
+</svg>


### PR DESCRIPTION
## Summary
- Add The MCP Company (themcp.company) to the builders page as an ALIGNED builder
- Include SVG logo sourced from their website
- Description: Dev tool giving control and visibility over agents and their MCP actions

## Test plan
- [ ] Verify the card renders correctly on the builders page
- [ ] Confirm the logo displays properly in both light and dark themes
- [ ] Confirm the link goes to https://themcp.company

Made with [Cursor](https://cursor.com)