### PR TITLE
Fix The MCP Company logo for light background

### DIFF
--- a/builders.mdx
+++ b/builders.mdx
@@ -1300,8 +1300,8 @@ description: Companies building AARM-conformant systems and those aligned with t
           }}
         >
           <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 64 64">
-            <rect x="6" y="18" width="34" height="34" fill="none" stroke="#f5f0e8" strokeWidth="2.5"/>
-            <rect x="20" y="8" width="34" height="34" fill="#f5f0e8"/>
+            <rect x="6" y="18" width="34" height="34" fill="none" stroke="#0a0a0f" strokeWidth="2.5"/>
+            <rect x="20" y="8" width="34" height="34" fill="#0a0a0f"/>
           </svg>
         </div>
         <span style={{ fontWeight: 700, fontSize: "15px" }}>The MCP Company</span>


### PR DESCRIPTION
The inline SVG for The MCP Company used light/cream (`#f5f0e8`) fill and stroke colors, making it invisible on the white card background. Swapped to dark (`#0a0a0f`) from the light mode version of their website so the logo renders correctly.

Before:
<img width="2106" height="490" alt="image" src="https://github.com/user-attachments/assets/0bbeca80-ebb4-4f00-81ff-1d6af2441734" />


After:
<img width="2061" height="583" alt="image" src="https://github.com/user-attachments/assets/915a6e25-9816-4fce-8b37-95723cd17aa3" />

Directly from their website:
<img width="1753" height="276" alt="image" src="https://github.com/user-attachments/assets/a04afea4-0d26-42e9-bbea-27247953c4b0" />

