### PR TITLE
Fix MDX parse error in formal.mdx

### DIFF
--- a/builders/formal.mdx
+++ b/builders/formal.mdx
@@ -82,7 +82,7 @@ Formal's relevance to AARM is direct: it operates at the wire-protocol chokepoin
 
 ### Platform capabilities
 
-<<CardGroup cols={2}>
+<CardGroup cols={2}>
   <Card title="Universal agent network proxy" icon="shield-halved">
     Proxies every AI agent network call including databases, infrastructure, and MCP servers. Native MCP protocol parsing enables decisions on the specific tool and arguments invoked rather than opaque TCP metadata.
   </Card>


### PR DESCRIPTION
## Summary
- Fix extra `<` on `<CardGroup>` tag at line 85 of `builders/formal.mdx` (`<<CardGroup` → `<CardGroup`)
- This syntax error causes `mintlify validate` to abort before completing broken-link and build checks

## Test plan
- [x] `mintlify validate` no longer reports parse error for `formal.mdx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)