### PR TITLE
Restore SovereignAI Security Labs builder card

### DIFF
--- a/builders.mdx
+++ b/builders.mdx
@@ -2076,6 +2076,61 @@ description: Companies building AARM-conformant systems and those aligned with t
     </div>
   </Card>
 
+<Card href="https://www.sovereignaisecurity.com">
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "flex-start",
+        gap: "10px",
+        height: "100%",
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", gap: "12px" }}>
+        <div
+          style={{
+            height: "32px",
+            width: "160px",
+            display: "flex",
+            alignItems: "center",
+          }}
+        >
+          <img
+            src="https://www.sovereignaisecurity.com/assets/logo-AZh8ZOWe.png"
+            alt=""
+            style={{
+              height: "32px",
+              width: "100%",
+              objectFit: "contain",
+              objectPosition: "left center",
+            }}
+          />
+        </div>
+        <span style={{ fontWeight: 700, fontSize: "15px" }}>SovereignAI Security Labs</span>
+      </div>
+
+      <p style={{ margin: 0, color: "#64748b", fontSize: "13px", lineHeight: 1.5 }}>
+        SentraGuard is a centralized, API-first GenAI security, observability, and guardrails platform that unifies visibility across browser, IDE, API, and endpoint/runtime surfaces through a single backend. It gives enterprises near real-time analysis and policy enforcement across cloud, on-prem, Kubernetes, workstation, VM, and containerized environments.
+      </p>
+
+      <div style={{ marginTop: "auto" }}>
+        <span
+          style={{
+            background: "#3b82f6",
+            color: "#fff",
+            padding: "2px 8px",
+            borderRadius: "6px",
+            fontSize: "10px",
+            fontWeight: 700,
+            letterSpacing: "0.02em",
+          }}
+        >
+          ALIGNED
+        </span>
+      </div>
+    </div>
+  </Card>
+
 </CardGroup>
 
 ---


### PR DESCRIPTION
## Summary
- restore the SovereignAI Security Labs `ALIGNED` card in `builders.mdx`
- keep the Optimus Labs addition from PR #40 intact
- reapply only the missing block that was previously merged in PR #39 and then dropped by the later edit

## Context
PR #39 merged the SovereignAI entry, but the subsequent merge in PR #40 rewrote the tail of the aligned builders list and removed that card. This PR is a narrow follow-up that restores only the missing SovereignAI block on top of the current upstream `main`.

## Notes
- fork `main` has been synced to upstream before creating this branch
- docs-only change; no tests required