### PR TITLE
Add Agen to builders registry (Aligned)

### DIFF
--- a/builders.mdx
+++ b/builders.mdx
@@ -59,6 +59,7 @@ export const BUILDERS = [
   { name: "Nudge Security", desc: "Govern the AI agent workforce. Discover, assess risk, enforce guardrails.", conformance: "Aligned", url: "https://www.nudgesecurity.com" },
   { name: "Kontext", desc: "Runtime authorization for AI agents with least-privilege tool calls, scoped credentials, audit trails, and instant revocation.", conformance: "Aligned", url: "https://kontext.security" },
 { name: "Kōtsū", desc: "Runtime governor for regulated workflows: specify, deploy, govern, and certify agentic operations.", conformance: "Aligned", url: "https://kotsu.ai" },
+  { name: "Agen", desc: "Enables organizations to securely expose enterprise context to internal agents, copilots, and AI workflows through an identity-aware control layer that governs access, reduces risk, and centralizes oversight.", conformance: "Aligned", url: "https://agen.co" },
 ];
 
 


### PR DESCRIPTION
Adds Agen to the builders registry under Aligned status.

- **Name:** Agen
- **URL:** https://agen.co
- **Status:** Aligned
- **Description:** Enables organizations to securely expose enterprise context to internal agents, copilots, and AI workflows through an identity-aware control layer that governs access, reduces risk, and centralizes oversight.

Agen is building in the AARM problem space — identity-aware runtime control for AI agents, MCP connectivity, policy enforcement, and audit. Happy to revise wording or formatting if you'd like.