### PR TITLE
feat: add Airia to Aligned builders

### DIFF
--- a/builders.mdx
+++ b/builders.mdx
@@ -61,6 +61,7 @@ export const BUILDERS = [
 { name: "Kōtsū", desc: "Runtime governor for regulated workflows: specify, deploy, govern, and certify agentic operations.", conformance: "Aligned", url: "https://kotsu.ai" },
   { name: "Agen", desc: "Enables organizations to securely expose enterprise context to internal agents, copilots, and AI workflows through an identity-aware control layer that governs access, reduces risk, and centralizes oversight.", conformance: "Aligned", url: "https://agen.co" },
 { name: "Tuent", desc: "Tuent’s Sentinel program catches AI agents the moment they go off-script, before damage hits production.", conformance: "Aligned", url: "https://tuent.ai/" },
+ { name: "Airia", desc: "AI Security and Governance platform with runtime security at two layers: an AI Gateway intercepts every model call and an MCP Gateway intercepts every tool call, both feeding a shared Policy Engine with prompt-injection, DLP, and identity-aware controls.", conformance: "Aligned", url: "https://airia.com" },
 ];
 
 


### PR DESCRIPTION
Adds Airia to the Aligned builders list per the registry's "Aligned" criteria (addresses one or more aspects of the AI runtime security problem; no conformance testing required for this status).

About Airia: AI Security and Governance platform delivering Active Governance for AI across a Discover, Approve, Mitigate, Monitor lifecycle. The runtime stack implements two AARM Protocol Gateway layers. An AI Gateway sits in front of every model call and an MCP Gateway sits in front of every tool call, with both calling a shared Policy Engine for prompt-injection scanning, DLP, and Block / Redact / Audit / Continue decisioning. Identity binding flows from the Identity Service through both gateways via a unified credential store with scoped, JIT credentials (Token Exchange, Pass-Through, M2M, OAuth/DCR). Shadow-AI discovery and endpoint reconciliation extend the same controls down to where AI clients actually run.

Status: Aligned today. Tracking toward AARM Core/Extended via internal workstreams on context accumulation, intent alignment, signed receipts, and step-up/defer flows.

Submitter: Spencer Reagan, PM, Integrations MCP team, Airia