### PR TITLE
Add General Analysis to builders registry

### DIFF
--- a/builders.mdx
+++ b/builders.mdx
@@ -61,6 +61,7 @@ export const BUILDERS = [
 { name: "Kōtsū", desc: "Runtime governor for regulated workflows: specify, deploy, govern, and certify agentic operations.", conformance: "Aligned", url: "https://kotsu.ai" },
   { name: "Agen", desc: "Enables organizations to securely expose enterprise context to internal agents, copilots, and AI workflows through an identity-aware control layer that governs access, reduces risk, and centralizes oversight.", conformance: "Aligned", url: "https://agen.co" },
 { name: "Tuent", desc: "Tuent’s Sentinel program catches AI agents the moment they go off-script, before damage hits production.", conformance: "Aligned", url: "https://tuent.ai/" },
+  { name: "General Analysis", desc: "Context-aware AI security platform for runtime guardrails, automated red teaming, and agent/tool risk visibility.", conformance: "Aligned", url: "https://generalanalysis.com" },
 ];
 
 


### PR DESCRIPTION
## Summary
- Add General Analysis to the AARM builders registry as an Aligned builder
- Link to https://generalanalysis.com

## Notes
- Listing as Aligned because conformance testing evidence is not included in this PR.