### PR TITLE
Add mcp-tap to builders registry (Aligned)

### DIFF
--- a/builders.mdx
+++ b/builders.mdx
@@ -63,6 +63,7 @@ export const BUILDERS = [
 { name: "Tuent", desc: "Tuent’s Sentinel program catches AI agents the moment they go off-script, before damage hits production.", conformance: "Aligned", url: "https://tuent.ai/" },
   { name: "General Analysis", desc: "Context-aware AI security platform for runtime guardrails, automated red teaming, and agent/tool risk visibility.", conformance: "Aligned", url: "https://generalanalysis.com" },
  { name: "SmartVerify", desc: "A Data Security and Compliance Layer for Enterprise AI. Every query inspected, scored, and logged in real time.", conformance: "Aligned", url: "https://www.smartverify.ai" },
+ { name: "mcp-tap", desc: "Open-source MCP traffic capture for stdio-transport servers. Tamper-evident HMAC-chained audit log with companion credential vault coffer-mcp.", conformance: "Aligned", url: "https://github.com/annawhooo/mcp-tap" },
 ];
 
 


### PR DESCRIPTION
Adds mcp-tap as an AARM-Aligned builder.

   mcp-tap is an open-source MCP transport-layer monitor for stdio-transport servers. It captures all JSON-RPC traffic to a tamper-evident HMAC-chained audit log, providing forensic evidence of agent actions. It addresses three AARM system components: Action Mediation Layer (stdio interception), Context Accumulator (the HMAC-chained log), and Receipt Generator (each log entry as a cryptographically chained receipt).

   mcp-tap is positioned as Aligned rather than Conformant. It is a passive observer, not a pre-execution enforcement point. AARM-Conformant systems require pre-execution interception with policy evaluation and authorization decisions.

   The companion tool [coffer-mcp](https://github.com/annawhooo/coffer-mcp) addresses the AARM Over-Privileged Credentials threat with a credential vault that keeps secrets out of the LLM context.

   - Repository: https://github.com/annawhooo/mcp-tap
   - AARM Alignment section in README: https://github.com/annawhooo/mcp-tap#aarm-alignment
   - License: Apache 2.0

   Independent security research, single-maintainer project.